### PR TITLE
fix: Ensure consistent test behavior with NonDex by resolving nondete…

### DIFF
--- a/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorUtils.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorUtils.java
@@ -24,6 +24,7 @@ import java.lang.reflect.Type;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -557,6 +558,12 @@ public final class ObjectInspectorUtils {
    */
   public static Field[] getDeclaredNonStaticFields(Class<?> c) {
     Field[] f = c.getDeclaredFields();
+    Arrays.sort(f, new Comparator<Field>() {
+      @Override
+      public int compare(Field a, Field b) {
+        return a.getName().compareTo(b.getName());
+      }
+    });
     ArrayList<Field> af = new ArrayList<Field>();
     for (int i = 0; i < f.length; ++i) {
       if (!Modifier.isStatic(f[i].getModifiers())) {


### PR DESCRIPTION
## Summary of PR

- Sorted fields from getDeclaredFields() to ensure consistent behavior across JVM versions and vendors.
- Resolved nondeterministic behavior causing intermittent failure in TestLazyBinaryColumnarSerDe#testLazyBinaryColumnarSerDeWithEmptyBinary

The root cause is in ObjectInspectorUtils.java, where getDeclaredFields() is used. According to its specification, "the elements in the returned array are unordered and not in any particular sequence" (see [documentation](https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getDeclaredFields--)).

### What changes were proposed in this pull request?

This pull request sorts the fields retrieved by the getDeclaredFields() method in ObjectInspectorUtils.java to ensure consistent behavior across different JVM versions and vendors. The non-deterministic behavior caused by the unordered fields was leading to intermittent failures in the test case TestLazyBinaryColumnarSerDe#testLazyBinaryColumnarSerDeWithEmptyBinary and other related tests.

### Why are the changes needed?

The getDeclaredFields() method does not guarantee a specific order in the returned fields, which can vary across JVM versions and vendors. This non-deterministic behavior was leading to inconsistencies in SerDe execution, causing test cases to fail intermittently. By sorting the fields, we ensure deterministic behavior, resolving the root cause of failures in tests like TestLazyBinaryColumnarSerDe#testLazyBinaryColumnarSerDeWithEmptyBinary.

### Does this PR introduce any user-facing change?

No, this PR does not introduce any user-facing changes. The modifications are internal to ensure consistent code execution and stability in test cases.

### Is the change a dependency upgrade?

No, this PR does not involve any dependency upgrades. It focuses solely on addressing the non-deterministic behavior within the existing code.

### How was this patch tested?

The patch was tested by running the affected test cases, including TestLazyBinaryColumnarSerDe#testLazyBinaryColumnarSerDeWithEmptyBinary using the tool [NonDex](https://github.com/TestingResearchIllinois/NonDex) which is a tool for detecting and debugging wrong assumptions on under-determined Java APIs. The sorting of fields was verified to prevent any non-deterministic behavior in SerDe execution, ensuring the tests passed consistently.

This was tested using NonDex where the following configurations were utilized:
`-DnondexMode=FULL`, `-DnondexRuns=10`

Command to replicate:

Navigate into the folder `hive/serde` after cloning the repo and running `mvn install`, then run the following:
```
cd hive/serde
mvn edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=TestLazyBinaryColumnarSerDe#testLazyBinaryColumnarSerDeWithEmptyBinary -DnondexMode=FULL -DnondexRuns=10
```